### PR TITLE
Introduce multiple issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,28 @@
+# GENERAL ISSUE: <!-- fill the title of regular issue -->
+
+## Bug Report
+
+- PMDK package version(s):                                           <!-- fill this out -->
+- OS(es) version(s):                                                 <!-- fill this out -->
+- ndctl version(s):                                                  <!-- fill this out -->
+- kernel version(s):                                                 <!-- fill this out -->
+- compiler, libraries, packaging and other related tools version(s): <!-- fill this out -->
+<!-- fill in also other useful environment data -->
+
+## Describe the issue:
+
+<!-- fill this out -->
+
+## Actual behavior:
+
+<!-- fill this out -->
+
+## Expected behavior:
+
+<!-- fill this out -->
+
+## Additional information about Priority and Help Requested:
+
+Are you willing to submit a pull request with a proposed change? (Yes, No)  <!-- check one if possible -->
+
+Requested priority: (Showstopper, High, Medium, Low)                        <!-- check one if possible -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,49 @@
+---
+name: Bug report
+about: Did you find a bug in PMDK? Please let us know.
+labels: "Type: Bug"
+---
+<!--
+Before creating new issue, ensure that similar issue wasn't already created
+  * Search: https://github.com/pmem/issues/issues
+
+Note that if you do not provide enough information to reproduce the issue, we may not be able to take action on your report.
+Remember this is just a minimal template. You can extend it with data you think may be useful.
+-->
+
+# ISSUE: <!-- fill the title of issue -->
+
+## Environment Information 
+
+- PMDK package version(s):                                           <!-- fill this out -->
+- OS(es) version(s):                                                 <!-- fill this out -->
+- ndctl version(s):                                                  <!-- fill this out -->
+- kernel version(s):                                                 <!-- fill this out -->
+- compiler, libraries, packaging and other related tools version(s): <!-- fill this out -->
+<!-- fill in also other useful environment data -->
+
+## Please provide a reproduction of the bug:
+
+<!-- fill this out -->
+
+## How often bug is revealed: (always, often, rare):  <!-- check one if possible -->
+
+<!-- describe special circumstances in section above -->
+
+## Actual behavior:
+
+<!-- fill this out -->
+
+## Expected behavior:
+
+<!-- fill this out -->
+
+## Details
+
+<!-- fill this out -->
+
+## Additional information about Priority and Help Requested:
+
+Are you willing to submit a pull request with a proposed change? (Yes, No)  <!-- check one if possible -->
+
+Requested priority: (Showstopper, High, Medium, Low)                        <!-- check one if possible -->

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,26 @@
+---
+name: Feature
+about: Feature your request
+labels: "Type: Feature"
+---
+# FEAT: <!-- fill the title of feature -->
+
+## Rationale
+
+<!-- fill this out -->
+
+## Description
+
+<!-- fill this out -->
+
+## API Changes
+
+<!-- fill this out -->
+
+## Implementation details
+
+<!-- fill this out if possible -->
+
+## Meta
+
+<!-- fill this out -->

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,15 @@
+---
+name: Question
+about: Do you have question regarding PMDK? Don't hesitate to ask.
+labels: "Type: Question"
+---
+# QUESTION: <!-- fill the title of question -->
+
+## Details
+
+<!-- fill this out -->
+
+<!--
+For questions and other non-bugs, you could use http://groups.google.com/group/pmem
+You could also chat with members of the PMDK team real-time on the #pmem IRC channel on OFTC
+-->


### PR DESCRIPTION
## Intention of this PR 

Introducing in pmem/issues repository issue templates could provide better support to managing issue tracker and set a good standard for reporting.

## Details
Currently there is active support for using label feature, but to perform operation like apply label you must have write access to repository. In some cases categorization could be done during creation of issue (feature/bug ) by person who report the issue, who doesn't need to have write access to repository. 
Template contain requested fields, which could be useful for maintainer to provide correct label, like for example OS version or Package version - this could be especially useful for people who create a first issue.

## Additional information
**The propose below is just a mockup, feel free to give me a feedback which category You want, which not or if You want some new category, please let me know.**

My intentions was to have following categories:

- **Bug report** - to report founded bug

- **Question** - to ask an question regarding functionality of PMDK

- **Feature** - this is a template for features which was planned by PMDK team ( TBH, I based on issue like e.g. #936 ) 

- ~~**Feature Request** - to propose feature request from someone outside PMDK team~~
